### PR TITLE
feat: Implement contextual sanity checks

### DIFF
--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -4,6 +4,7 @@ import time
 from typing import Tuple, Dict, Any
 
 import psutil
+import os
 
 def run_pytest(test_dir: str = "tests/") -> Tuple[bool, str]:
     """
@@ -29,6 +30,32 @@ def run_pytest(test_dir: str = "tests/") -> Tuple[bool, str]:
         return success, output
     except Exception as e:
         return False, f"Erro ao executar pytest: {str(e)}"
+
+
+def check_file_existence(file_paths: list[str]) -> Tuple[bool, str]:
+    """
+    Verifica se todos os arquivos especificados existem.
+
+    Args:
+        file_paths: Uma lista de caminhos de arquivo para verificar.
+
+    Returns:
+        Tuple[bool, str]: (success, message)
+        - success: True se todos os arquivos existirem, False caso contrário.
+        - message: Mensagem indicando o resultado.
+    """
+    if not file_paths:
+        return False, "Nenhum caminho de arquivo fornecido para verificação."
+
+    missing_files = []
+    for file_path in file_paths:
+        if not os.path.exists(file_path):
+            missing_files.append(file_path)
+
+    if not missing_files:
+        return True, "Todos os arquivos especificados existem."
+    else:
+        return False, f"Arquivo(s) não encontrado(s): {', '.join(missing_files)}"
 
 
 def run_in_sandbox(temp_dir_path: str, objective: str) -> Dict[str, Any]:

--- a/hephaestus_config.json
+++ b/hephaestus_config.json
@@ -1,13 +1,32 @@
 {
   "validation_strategies": {
     "SYNTAX_ONLY": {
-      "steps": ["syntax_validation"]
+      "steps": ["validate_syntax", "apply_changes"],
+      "sanity_check_step": "run_pytest"
     },
     "BENCHMARK_ONLY": {
-      "steps": ["run_benchmark"]
+      "steps": ["run_benchmark_validation", "apply_changes"],
+      "sanity_check_step": "run_pytest"
     },
-    "SYNTAX_AND_BENCHMARK": {
-      "steps": ["syntax_validation", "run_pytest_validation", "run_benchmark"]
+    "SYNTAX_AND_PYTEST": {
+      "steps": ["validate_syntax", "run_pytest_validation", "apply_changes"],
+      "sanity_check_step": "run_pytest"
+    },
+    "FULL_VALIDATION": {
+      "steps": ["validate_syntax", "run_pytest_validation", "run_benchmark_validation", "apply_changes"],
+      "sanity_check_step": "run_pytest"
+    },
+    "DOC_UPDATE_STRATEGY": {
+      "steps": ["apply_changes"],
+      "sanity_check_step": "check_file_existence"
+    },
+    "CONFIG_UPDATE_STRATEGY": {
+      "steps": ["validate_json_syntax", "apply_changes"],
+      "sanity_check_step": "check_file_existence"
+    },
+    "DISCARD": {
+      "steps": [],
+      "sanity_check_step": "skip_sanity_check"
     }
   }
 }


### PR DESCRIPTION
Refactored the sanity check mechanism to be configurable per validation strategy.

- `hephaestus_config.json`:
  - Validation strategies now include a `sanity_check_step` key (e.g., "run_pytest", "check_file_existence", "skip_sanity_check").
  - Added new strategies like `DOC_UPDATE_STRATEGY` and `CONFIG_UPDATE_STRATEGY` utilizing `check_file_existence`.

- `agent/tool_executor.py`:
  - Added new tool `check_file_existence(file_paths: list[str])` which verifies if all specified files exist.

- `main.py`:
  - The post-cycle sanity check logic now dynamically dispatches to the tool specified in the strategy's `sanity_check_step`.
  - Handles `run_pytest`, `check_file_existence`, and `skip_sanity_check`.
  - Failure reasons are now more specific (e.g., `REGRESSION_DETECTED_BY_CHECK_FILE_EXISTENCE`).

This resolves the issue where `pytest` was inappropriately used for non-code changes (like documentation), causing false positive regressions. The agent can now use more appropriate sanity checks based on the context of the applied changes.