### PR TITLE
feat: Implement memory cleanup routine for objectives

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,8 +82,12 @@ agente_autonomo/
   - *Aplica uma lista de instruções de patch aos arquivos.*
 
 ### Arquivo: `agent/memory.py`
-- **Classe:** `Memory`
-  - *Manages persistent memory for the Hephaestus agent, storing historical data*
+- **Classe:** `Memory(filepath: str = "HEPHAESTUS_MEMORY.json", max_objectives_history: int = 20)`
+  - *Manages persistent memory for the Hephaestus agent, storing historical data about objectives, failures, and acquired capabilities. Includes a cleanup routine for objectives.*
+  - **Atributo:** `max_objectives_history: int` - *Maximum number of objectives to keep in history (default: 20).*
+  - **Atributo:** `cycle_count: int` - *Internal counter to trigger cleanup every 5 objective additions.*
+  - **Método:** `cleanup_memory()` - *Removes old, duplicate objectives, keeping the most recent ones up to `max_objectives_history`. Triggered every 5 objective additions.*
+  - *Outros métodos incluem `load`, `save`, `add_completed_objective`, `add_failed_objective`, `add_capability`, `get_history_summary`, `get_full_history_for_prompt`.*
 
 ### Arquivo: `agent/tool_executor.py`
 - **Função:** `run_pytest(test_dir: str='tests/', cwd: str | Path | None=None)`

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -13,10 +13,17 @@ def test_memory_initialization(temp_memory_file):
     """Test that Memory initializes correctly with a filepath."""
     memory = Memory(filepath=str(temp_memory_file))
     assert memory.filepath == str(temp_memory_file)
+    assert memory.max_objectives_history == 20 # Default
+    assert memory.cycle_count == 0
     assert memory.completed_objectives == []
     assert memory.failed_objectives == []
     assert memory.acquired_capabilities == []
-    assert memory.recent_objectives_log == [] # Verificar novo atributo
+    assert memory.recent_objectives_log == []
+
+def test_memory_initialization_custom_max_history(temp_memory_file):
+    """Test Memory initialization with custom max_objectives_history."""
+    memory = Memory(filepath=str(temp_memory_file), max_objectives_history=10)
+    assert memory.max_objectives_history == 10
 
 def test_save_and_load_empty_memory(temp_memory_file):
     """Test saving and loading an empty memory."""
@@ -302,6 +309,182 @@ def test_recent_objectives_log_tracking_and_trimming(temp_memory_file):
     assert len(new_memory.recent_objectives_log) == 5
     assert new_memory.recent_objectives_log[4]["objective"] == "Obj Comp 3"
     assert new_memory.recent_objectives_log[0]["objective"] == "Obj Fail 2"
+
+
+def test_cleanup_memory_trigger_and_cycle_reset(temp_memory_file):
+    """Test that cleanup_memory is triggered every 5 calls and cycle_count resets."""
+    memory = Memory(filepath=str(temp_memory_file), max_objectives_history=3)
+    assert memory.cycle_count == 0
+
+    for i in range(4): # Add 4 objectives
+        memory.add_completed_objective(f"Obj {i}", "s", "d")
+        assert memory.cycle_count == i + 1
+        assert len(memory.completed_objectives) == i + 1 # No cleanup yet
+
+    # Add 5th objective - should trigger cleanup
+    memory.add_completed_objective("Obj 4", "s", "d")
+    assert memory.cycle_count == 0 # Reset after cleanup
+    # Objectives list is sorted chronologically: Obj 2, Obj 3, Obj 4
+    assert len(memory.completed_objectives) == 3
+    assert memory.completed_objectives[0]["objective"] == "Obj 2" # Oldest of the kept
+    assert memory.completed_objectives[1]["objective"] == "Obj 3"
+    assert memory.completed_objectives[2]["objective"] == "Obj 4" # Most recent of the kept
+
+    # Add another 4 objectives
+    for i in range(5, 9): # Objs 5, 6, 7, 8
+        memory.add_failed_objective(f"Obj {i}", "f", "d")
+        assert memory.cycle_count == i - 4 # cycle is 1, 2, 3, 4
+
+    # Current objectives: Comp: [Obj 4, Obj 3, Obj 2], Failed: [Obj 5, Obj 6, Obj 7, Obj 8]
+    # Total = 7, but lists are separate.
+    assert len(memory.completed_objectives) == 3
+    assert len(memory.failed_objectives) == 4
+
+    # Add 10th objective (5th since last cleanup) - should trigger cleanup
+    memory.add_completed_objective("Obj 9", "s", "d") # This is Obj 9
+    assert memory.cycle_count == 0
+
+    # After cleanup, with max_history = 3.
+    # Combined and sorted: Obj 9(C), Obj 8(F), Obj 7(F), Obj 6(F), Obj 5(F), Obj 4(C), Obj 3(C), Obj 2(C)
+    # Kept (top 3): Obj 9(C), Obj 8(F), Obj 7(F)
+    # Separated: Completed: [Obj 9], Failed: [Obj 8, Obj 7]
+
+    assert len(memory.completed_objectives) == 1, f"Completed: {memory.completed_objectives}"
+    assert memory.completed_objectives[0]["objective"] == "Obj 9"
+
+    assert len(memory.failed_objectives) == 2, f"Failed: {memory.failed_objectives}"
+    # Failed objectives list is sorted chronologically: Obj 7, Obj 8
+    assert memory.failed_objectives[0]["objective"] == "Obj 7" # Oldest of the kept failed
+    assert memory.failed_objectives[1]["objective"] == "Obj 8" # Most recent of the kept failed
+
+
+def test_cleanup_memory_deduplication(temp_memory_file):
+    """Test that cleanup_memory removes duplicate objectives, keeping the latest."""
+    memory = Memory(filepath=str(temp_memory_file), max_objectives_history=5)
+
+    # Add objectives, some with same name but different timestamps/details
+    memory.add_completed_objective("Duplicate Obj A", "s", "first entry", ) # 1st call
+    time.sleep(0.01)
+    memory.add_failed_objective("Unique Obj B", "f", "details B")      # 2nd call
+    time.sleep(0.01)
+    memory.add_completed_objective("Duplicate Obj A", "s", "second entry, updated") # 3rd call
+    time.sleep(0.01)
+    memory.add_failed_objective("Unique Obj C", "f", "details C")      # 4th call
+    time.sleep(0.01)
+
+    # 5th call, triggers cleanup
+    memory.add_completed_objective("Unique Obj D", "s", "details D")
+    assert memory.cycle_count == 0
+
+    # Expected after cleanup (max_history=5):
+    # Unique D (Comp), Unique C (Fail), Duplicate Obj A (Comp, second entry), Unique B (Fail)
+    # Total 4 unique objectives by name.
+
+    assert len(memory.completed_objectives) == 2
+    assert len(memory.failed_objectives) == 2
+
+    completed_names = [obj["objective"] for obj in memory.completed_objectives]
+    failed_names = [obj["objective"] for obj in memory.failed_objectives]
+
+    assert "Unique Obj D" in completed_names
+    assert "Duplicate Obj A" in completed_names
+    assert "Unique Obj C" in failed_names
+    assert "Unique Obj B" in failed_names
+
+    # Check that the latest version of "Duplicate Obj A" was kept
+    for obj in memory.completed_objectives:
+        if obj["objective"] == "Duplicate Obj A":
+            assert obj["details"] == "second entry, updated"
+            break
+    else:
+        assert False, "Duplicate Obj A not found in completed objectives"
+
+def test_cleanup_memory_history_limit(temp_memory_file):
+    """Test that cleanup_memory respects max_objectives_history."""
+    max_hist = 2
+    memory = Memory(filepath=str(temp_memory_file), max_objectives_history=max_hist)
+
+    # Add 4 objectives, cleanup won't trigger yet
+    memory.add_completed_objective("Obj 0", "s", "d0") # cycle 1
+    memory.add_failed_objective("Obj 1", "f", "d1")    # cycle 2
+    memory.add_completed_objective("Obj 2", "s", "d2") # cycle 3
+    memory.add_failed_objective("Obj 3", "f", "d3")    # cycle 4
+
+    assert len(memory.completed_objectives) == 2
+    assert len(memory.failed_objectives) == 2
+
+    # Add 5th objective, triggering cleanup
+    memory.add_completed_objective("Obj 4", "s", "d4") # cycle 0 (reset)
+
+    # All objectives: Obj 4(C), Obj 3(F), Obj 2(C), Obj 1(F), Obj 0(C)
+    # Sorted by date (most recent first): Obj 4, Obj 3, Obj 2, Obj 1, Obj 0
+    # Kept (max_hist = 2): Obj 4, Obj 3
+    # Separated: Completed: [Obj 4], Failed: [Obj 3]
+
+    assert len(memory.completed_objectives) == 1
+    assert memory.completed_objectives[0]["objective"] == "Obj 4"
+
+    assert len(memory.failed_objectives) == 1
+    assert memory.failed_objectives[0]["objective"] == "Obj 3"
+
+    # Add 5 more objectives (total 10, 2nd cleanup)
+    memory.add_completed_objective("Obj 5", "s", "d5") # cycle 1
+    memory.add_failed_objective("Obj 6", "f", "d6")    # cycle 2
+    memory.add_completed_objective("Obj 7", "s", "d7") # cycle 3
+    memory.add_failed_objective("Obj 8", "f", "d8")    # cycle 4
+    memory.add_completed_objective("Obj 9", "s", "d9") # cycle 0 (reset)
+
+    # Previous state: Comp:[Obj 4], Fail:[Obj 3]
+    # Added: C:Obj5, F:Obj6, C:Obj7, F:Obj8, C:Obj9
+    # All before this cleanup: Obj 9(C), Obj 8(F), Obj 7(C), Obj 6(F), Obj 5(C), Obj 4(C), Obj 3(F)
+    # Sorted by date: Obj 9, Obj 8, Obj 7, Obj 6, Obj 5, Obj 4, Obj 3
+    # Kept (max_hist = 2): Obj 9, Obj 8
+    # Separated: Completed: [Obj 9], Failed: [Obj 8]
+
+    assert len(memory.completed_objectives) == 1
+    assert memory.completed_objectives[0]["objective"] == "Obj 9"
+
+    assert len(memory.failed_objectives) == 1
+    assert memory.failed_objectives[0]["objective"] == "Obj 8"
+
+def test_cleanup_memory_no_action_if_cycle_not_reached(temp_memory_file):
+    """Test that cleanup_memory does nothing if cycle count is not 5."""
+    memory = Memory(filepath=str(temp_memory_file), max_objectives_history=1)
+    memory.add_completed_objective("Obj 1", "s", "d")
+    memory.add_completed_objective("Obj 2", "s", "d")
+    memory.add_failed_objective("Obj 3", "f", "d")
+
+    assert memory.cycle_count == 3
+    assert len(memory.completed_objectives) == 2
+    assert len(memory.failed_objectives) == 1
+
+    # Manually call cleanup (though it's private, for testing the guard)
+    # In the actual code, _add_to_recent_objectives_log calls it.
+    # The test for `add_completed_objective` already covers the cycle increment.
+    # Here we just want to ensure if we somehow call it early, it doesn't clean.
+    # This is more of a conceptual test as direct call to cleanup_memory isn't typical.
+    # Let's simulate the state just before the 5th add.
+    memory.cycle_count = 4 # Simulate being just before the 5th call
+    memory.cleanup_memory() # This call itself will increment cycle_count to 5, so it WILL clean.
+
+    # Re-think: The test should verify that if add_objective is called < 4 times,
+    # the lists are not trimmed beyond max_history *yet*.
+    memory = Memory(filepath=str(temp_memory_file), max_objectives_history=1)
+    memory.add_completed_objective("Test 1", "s", "d") # cycle 1
+    memory.add_completed_objective("Test 2", "s", "d") # cycle 2
+    memory.add_completed_objective("Test 3", "s", "d") # cycle 3
+
+    assert memory.cycle_count == 3
+    assert len(memory.completed_objectives) == 3 # Max history is 1, but cleanup not run
+
+    memory.add_completed_objective("Test 4", "s", "d") # cycle 4
+    assert memory.cycle_count == 4
+    assert len(memory.completed_objectives) == 4
+
+    memory.add_completed_objective("Test 5", "s", "d") # cycle 0 (cleaned)
+    assert memory.cycle_count == 0
+    assert len(memory.completed_objectives) == 1 # Now cleaned to max_history
+    assert memory.completed_objectives[0]["objective"] == "Test 5"
 
 
 # To run these tests:


### PR DESCRIPTION
Adds a cleanup_memory() method to the Memory class that runs every 5 objective additions.

This routine:
- Removes duplicate objectives, keeping the most recent entry.
- Limits the total number of completed and failed objectives stored, based on the `max_objectives_history` parameter (default 20).

This helps prevent memory pollution and keeps the agent focused on relevant, recent objectives.

Updated tests to cover the new functionality and ensure correct behavior regarding deduplication, history limits, and cycle triggers.