### PR TITLE
Fix duplicate method definition in main.py

### DIFF
--- a/main.py
+++ b/main.py
@@ -324,8 +324,6 @@ hephaestus.log
         return True
 
     def _reset_cycle_state(self):
-        current_objective = self.state.get("current_objective")
-    def _reset_cycle_state(self):
         # current_objective = self.state.get("current_objective") # Antes da dataclass
         current_objective = self.state.current_objective # Com dataclass
 


### PR DESCRIPTION
## Summary
- remove leftover `_reset_cycle_state` definition in `main.py`

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: cannot import name `_call_llm_api`)*

------
https://chatgpt.com/codex/tasks/task_e_685ef0e9711883208dee9b145b347b8d