### PR TITLE
Update README for API key and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,10 @@ Autonomous AI agent for software development
 
 1. Clone this repository
 2. Install dependencies: `pip install -r requirements.txt`
-3. Configure your OpenRouter API key in `hephaestus_config.json`:
-```json
-{
-  "api_key": "your-api-key-here",
-  "default_model": "gpt-3.5-turbo"
-}
-```
-4. Run the agent: `python main.py`
+3. Set the `OPENROUTER_API_KEY` environment variable with your OpenRouter key
+   (you can place it in a `.env` file or export it directly).
+4. Optionally adjust `hephaestus_config.json` for model and runtime settings.
+5. Run the agent: `python main.py`
 
 ## Features
 
@@ -24,6 +20,17 @@ Autonomous AI agent for software development
 ## Configuration
 
 See `hephaestus_config.json` for available options.
+
+## Testing
+
+Run the test suite with [pytest](https://docs.pytest.org/):
+
+```bash
+pytest
+```
+
+Ensure the `OPENROUTER_API_KEY` variable is set when executing tests, as many
+tests rely on its presence.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary
- document OPENROUTER_API_KEY environment setup
- add pytest instructions

## Testing
- `pytest -q` *(fails: ImportError: cannot import name '_call_llm_api')*

------
https://chatgpt.com/codex/tasks/task_e_685ef0f06eb88320b910e3d93bab2869