### PR TITLE
Add _call_llm_api wrappers

### DIFF
--- a/agent/agents.py
+++ b/agent/agents.py
@@ -4,7 +4,18 @@ import logging
 import traceback # Keep if parse_json_response uses it, otherwise remove
 from typing import Optional, Dict, Any, List, Tuple
 
-from agent.utils.llm_client import call_llm_api # IMPORT THE CENTRALIZED FUNCTION
+from agent.utils.llm_client import call_llm_api
+
+def _call_llm_api(
+    api_key: str,
+    model: str,
+    prompt: str,
+    temperature: float,
+    base_url: str,
+    logger: logging.Logger,
+) -> Tuple[Optional[str], Optional[str]]:
+    """Lightweight wrapper for ``call_llm_api`` from ``agent.utils.llm_client``."""
+    return call_llm_api(api_key, model, prompt, temperature, base_url, logger)
 
 # Esta função é uma cópia de agent.brain.parse_json_response
 # Idealmente, seria movida para um módulo de utilitários compartilhado se usada em mais lugares.

--- a/agent/brain.py
+++ b/agent/brain.py
@@ -19,10 +19,20 @@ import logging
 # - generate_capacitation_objective
 # - generate_commit_message
 
-from agent.project_scanner import analyze_code_metrics # New import
-from agent.utils.llm_client import call_llm_api # IMPORT THE CENTRALIZED FUNCTION
+from agent.project_scanner import analyze_code_metrics
+from agent.utils.llm_client import call_llm_api
 
-# _call_llm_api was removed from here.
+def _call_llm_api(
+    api_key: str,
+    model: str,
+    prompt: str,
+    temperature: float,
+    base_url: str,
+    logger: logging.Logger,
+) -> Tuple[Optional[str], Optional[str]]:
+    """Lightweight wrapper for ``call_llm_api`` from ``agent.utils.llm_client``."""
+    return call_llm_api(api_key, model, prompt, temperature, base_url, logger)
+
 
 def generate_next_objective(
     api_key: str,


### PR DESCRIPTION
## Summary
- restore lightweight `_call_llm_api` helpers in `agent/brain.py` and `agent/agents.py`
- these wrappers delegate to `agent.utils.llm_client.call_llm_api`

## Testing
- `python -m py_compile agent/agents.py agent/brain.py`
- `pytest -q tests/test_agents.py::test_agents_call_llm_api_success -q` *(fails: AttributeError: module 'agent.agents' has no attribute 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_685ef0e9956c8320bee50c8cb7d4f31b