### PR TITLE
Replace deprecated logger.warn usages

### DIFF
--- a/agent/cycle_runner.py
+++ b/agent/cycle_runner.py
@@ -103,7 +103,9 @@ def run_cycles(agent: "HephaestusAgent") -> None:
                 reason="DEGENERATIVE_LOOP_DETECTED",
                 details=f"O objetivo falhou {failure_count} vezes consecutivas. Pausando processamento deste objetivo.",
             )
-            agent.logger.warn(f"O objetivo \"{current_objective}\" será descartado devido a loop degenerativo.")
+            agent.logger.warning(
+                f"O objetivo \"{current_objective}\" será descartado devido a loop degenerativo."
+            )
             continue
 
         try:
@@ -114,7 +116,9 @@ def run_cycles(agent: "HephaestusAgent") -> None:
                 agent.logger.error("Falha crítica ao gerar manifesto. Encerrando ciclo.")
                 break
             if not agent._run_architect_phase():
-                agent.logger.warn("Falha na fase do Arquiteto. Pulando para o próximo objetivo se houver.")
+                agent.logger.warning(
+                    "Falha na fase do Arquiteto. Pulando para o próximo objetivo se houver."
+                )
                 agent.memory.add_failed_objective(current_objective, "ARCHITECT_PHASE_FAILED", "ArchitectAgent could not generate a plan.")
                 if not agent.objective_stack and not agent.continuous_mode:
                     break
@@ -276,7 +280,9 @@ def run_cycles(agent: "HephaestusAgent") -> None:
                     agent.logger.info(f"Próximo objetivo: {next_obj}")
 
             if not success:
-                agent.logger.warn(f"\nFALHA NO CICLO! Razão Final: {reason}\nContexto Final: {context}")
+                agent.logger.warning(
+                    f"\nFALHA NO CICLO! Razão Final: {reason}\nContexto Final: {context}"
+                )
                 agent.memory.add_failed_objective(objective=agent.state.current_objective or "N/A", reason=reason, details=context)
 
                 correctable_failure_reasons = {
@@ -297,7 +303,9 @@ def run_cycles(agent: "HephaestusAgent") -> None:
                     correctable_failure_reasons.add(reason)
 
                 if reason in correctable_failure_reasons:
-                    agent.logger.warn(f"Falha corrigível ({reason}). Gerando objetivo de correção.")
+                    agent.logger.warning(
+                        f"Falha corrigível ({reason}). Gerando objetivo de correção."
+                    )
                     agent.objective_stack.append(current_objective)
 
                     original_patches_json = json.dumps(agent.state.get_patches_to_apply(), indent=2) if agent.state.action_plan_data else "N/A"

--- a/agent/patch_applicator.py
+++ b/agent/patch_applicator.py
@@ -177,7 +177,9 @@ def apply_patches(instructions: list[dict], logger: logging.Logger, base_path: s
                             overall_success = False
                             continue
                     else:
-                        logger.warn(f"Arquivo '{full_path}' não existe. Nada para deletar com DELETE_BLOCK.")
+                        logger.warning(
+                            f"Arquivo '{full_path}' não existe. Nada para deletar com DELETE_BLOCK."
+                        )
                         continue
 
                 if not block_to_delete_pattern: # String vazia
@@ -186,7 +188,9 @@ def apply_patches(instructions: list[dict], logger: logging.Logger, base_path: s
                     continue
 
                 if not full_path.exists():
-                    logger.warn(f"Arquivo '{full_path}' não existe. Nada para deletar com DELETE_BLOCK.")
+                    logger.warning(
+                        f"Arquivo '{full_path}' não existe. Nada para deletar com DELETE_BLOCK."
+                    )
                     continue
 
 

--- a/agent/validation_steps/pytest_validator.py
+++ b/agent/validation_steps/pytest_validator.py
@@ -16,7 +16,9 @@ class PytestValidator(ValidationStep):
         success, details = run_pytest(test_dir='tests/', cwd=self.base_path)
 
         if not success:
-            self.logger.warn(f"Pytest failed in '{self.base_path}': {details}")
+            self.logger.warning(
+                f"Pytest failed in '{self.base_path}': {details}"
+            )
             reason_code = "PYTEST_FAILURE_IN_SANDBOX" if self.use_sandbox else "PYTEST_FAILURE"
             return False, reason_code, details
 

--- a/agent/validation_steps/syntax_validator.py
+++ b/agent/validation_steps/syntax_validator.py
@@ -32,13 +32,17 @@ class SyntaxValidator(ValidationStep):
             if file_path_relative.endswith(".py"):
                 is_valid, msg, _ = validate_python_code(full_file_path_in_target, self.logger)
                 if not is_valid:
-                    self.logger.warn(f"Python syntax error in {full_file_path_in_target}: {msg}")
+                    self.logger.warning(
+                        f"Python syntax error in {full_file_path_in_target}: {msg}"
+                    )
                     all_syntax_valid = False
                     error_details.append(f"{file_path_relative}: {msg}")
             elif file_path_relative.endswith(".json"):
                 is_valid, msg = validate_json_syntax(full_file_path_in_target, self.logger)
                 if not is_valid:
-                    self.logger.warn(f"JSON syntax error in {full_file_path_in_target}: {msg}")
+                    self.logger.warning(
+                        f"JSON syntax error in {full_file_path_in_target}: {msg}"
+                    )
                     all_syntax_valid = False
                     error_details.append(f"{file_path_relative}: {msg}")
 

--- a/main.py
+++ b/main.py
@@ -343,7 +343,9 @@ class HephaestusAgent:
                         self.logger.error(f"CRITICAL ERROR promoting changes from sandbox to real project: {e}", exc_info=True)
                         self.state.validation_result = (False, "PROMOTION_FAILED", str(e))
                 elif not current_validation_succeeded:
-                    self.logger.warn(f"Validation in sandbox failed (Reason: {current_reason}). Patches will not be promoted. Details: {current_details}")
+                    self.logger.warning(
+                        f"Validation in sandbox failed (Reason: {current_reason}). Patches will not be promoted. Details: {current_details}"
+                    )
                     # The validation_result is already set to the failure.
 
             # Final check if state is still pending (should be resolved by now)

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -12,7 +12,7 @@ def mock_logger():
     logger = MagicMock(spec=logging.Logger)
     logger.info = MagicMock()
     logger.debug = MagicMock()
-    logger.warn = MagicMock()
+    logger.warning = MagicMock()
     logger.error = MagicMock()
     return logger
 

--- a/tests/test_brain.py
+++ b/tests/test_brain.py
@@ -33,7 +33,7 @@ def mock_logger():
     logger = MagicMock(spec=logging.Logger)
     logger.info = MagicMock()
     logger.debug = MagicMock()
-    logger.warn = MagicMock()
+    logger.warning = MagicMock()
     logger.error = MagicMock()
     return logger
 
@@ -109,7 +109,7 @@ def test_generate_next_objective_api_error(mock_call_llm_api, mock_logger):
             memory_summary=""
         )
         assert "Analisar" in objective # Verificação mais flexível
-        mock_logger.warn.assert_called_with("Resposta vazia do LLM para próximo objetivo.")
+        mock_logger.warning.assert_called_with("Resposta vazia do LLM para próximo objetivo.")
 
 
 @patch('agent.brain._call_llm_api')


### PR DESCRIPTION
## Summary
- use `logger.warning` throughout the codebase
- update tests to expect `warning`

## Testing
- `pytest -q` *(fails: AttributeError module 'agent.agents' has no attribute 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_685ef776e8c88320a3babe770981c45c