### PR TITLE
Handle bad config files gracefully

### DIFF
--- a/main.py
+++ b/main.py
@@ -132,8 +132,41 @@ class HephaestusAgent:
 
     @staticmethod
     def load_config() -> dict:
-        with open("hephaestus_config.json", "r", encoding="utf-8") as f:
-            return json.load(f)
+        """Load configuration from ``hephaestus_config.json`` with fallbacks.
+
+        Returns an empty dictionary if both the main and fallback configuration
+        files are missing or malformed. Errors are logged for visibility.
+        """
+        config_logger = logging.getLogger(__name__)
+
+        try:
+            with open("hephaestus_config.json", "r", encoding="utf-8") as f:
+                return json.load(f)
+        except FileNotFoundError:
+            config_logger.error(
+                "Configuration file 'hephaestus_config.json' not found. "
+                "Falling back to defaults."
+            )
+        except json.JSONDecodeError as e:
+            config_logger.error(
+                f"Error parsing 'hephaestus_config.json': {e}. "
+                "Falling back to defaults."
+            )
+
+        # Try fallback configuration
+        try:
+            with open("example_config.json", "r", encoding="utf-8") as f:
+                config_logger.info(
+                    "Loaded default configuration from 'example_config.json'."
+                )
+                return json.load(f)
+        except (FileNotFoundError, json.JSONDecodeError) as e:
+            config_logger.error(
+                "Fallback configuration 'example_config.json' could not be "
+                f"loaded: {e}. Using empty defaults."
+            )
+
+        return {}
 
     def _generate_manifest(self) -> bool:
         self.logger.info("Gerando manifesto do projeto (AGENTS.md)...")

--- a/tests/test_config_loading.py
+++ b/tests/test_config_loading.py
@@ -1,0 +1,28 @@
+import os
+import json
+import logging
+from main import HephaestusAgent
+
+
+def test_load_config_file_not_found(tmp_path, caplog):
+    os.chdir(tmp_path)
+    caplog.set_level(logging.ERROR)
+    config = HephaestusAgent.load_config()
+    assert config == {}
+    assert "hephaestus_config.json" in caplog.text
+    assert "not found" in caplog.text
+
+
+def test_load_config_malformed_json(tmp_path, caplog):
+    os.chdir(tmp_path)
+    # create malformed main config
+    with open("hephaestus_config.json", "w", encoding="utf-8") as f:
+        f.write("{ invalid json")
+    fallback = {"default": True}
+    with open("example_config.json", "w", encoding="utf-8") as f:
+        json.dump(fallback, f)
+    caplog.set_level(logging.INFO)
+    config = HephaestusAgent.load_config()
+    assert config == fallback
+    assert "Error parsing" in caplog.text
+    assert "example_config.json" in caplog.text


### PR DESCRIPTION
## Summary
- improve `load_config` to log errors and fall back to defaults
- add regression tests for missing or malformed config files

## Testing
- `pytest -q`
- `pytest tests/test_config_loading.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685ef784c92083208fa2a6953b1079e7