### PR TITLE
Remove bad text artifact in patch_applicator

### DIFF
--- a/agent/patch_applicator.py
+++ b/agent/patch_applicator.py
@@ -457,6 +457,7 @@ def apply_patches(instructions: list[dict], logger: logging.Logger, base_path: s
                     # A abordagem mais simples é que o LLM forneça blocos que incluam newlines para deleção.
                     logger.debug(
                         f"Bloco removido para '{block_to_delete_pattern}' em '{full_path}'.")
+                    pass
                 elif full_path.exists():
                     logger.warning(
                         f"Nenhuma deleção realizada para '{block_to_delete_pattern}' em '{full_path}'.")


### PR DESCRIPTION
## Summary
- cleanup DELETE_BLOCK handling so the `if deleted:` block ends cleanly
- run the test suite

## Testing
- `pytest tests/test_patch_applicator.py -q`
- `pytest tests/test_hephaestus.py -q` *(fails: AssertionError in degenerative loop detection)*

------
https://chatgpt.com/codex/tasks/task_e_685f00cd5ab88320ba317f2748f7c1b7