### PR TITLE
Make config optional for generate_next_objective

### DIFF
--- a/agent/brain.py
+++ b/agent/brain.py
@@ -30,7 +30,7 @@ def generate_next_objective(
     current_manifest: str,
     logger: logging.Logger, # Changed type hint from Any
     project_root_dir: str,
-    config: Dict[str, Any], # Added config parameter for thresholds
+    config: Dict[str, Any] | None = None,
     base_url: str = "https://openrouter.ai/api/v1",
     memory_summary: Optional[str] = None
 ) -> str:
@@ -38,6 +38,8 @@ def generate_next_objective(
     Generates the next evolutionary objective using a lightweight model and code analysis.
     """
     if logger: logger.info("Generating next objective...")
+
+    config = config or {}
 
     # 1. Analyze code metrics using thresholds from config
     code_analysis_summary_str = ""


### PR DESCRIPTION
## Summary
- make the `config` parameter optional in `generate_next_objective`
- default to empty dict when not provided

## Testing
- `pytest tests/test_brain.py::test_generate_next_objective_success tests/agent/test_brain.py::TestBrainFunctions::test_generate_next_objective_uses_config_thresholds -q`
- `pytest -q` *(fails: test_generate_next_objective_api_error, test_generate_next_objective_empty_manifest, test_generate_next_objective_with_memory, test_generate_capacitation_objective_success, test_generate_capacitation_objective_api_error, test_generate_capacitation_objective_with_memory, test_degenerative_loop_detection)*

------
https://chatgpt.com/codex/tasks/task_e_685f00ce770483209a48d98bb3190fb8