### PR TITLE
feat: Implement PoC for asynchronous LLM calls

### DIFF
--- a/agent/utils/llm_client.py
+++ b/agent/utils/llm_client.py
@@ -1,28 +1,46 @@
 import json
-import logging # Changed from 'Any' to 'logging' for proper type hinting
-import requests
-import traceback # Kept for now, as it was in one of the versions
-from typing import Optional, Tuple, Any # 'Any' can be replaced if logger type is more specific
+import logging
+import traceback
+from typing import Optional, Tuple
 
-# Common function to call LLM API
-# Taken from agent/agents.py as it seemed slightly more complete (e.g., no traceback import)
-# but added back traceback for safety if it was used in specific error conditions.
-def call_llm_api(api_key: str, model: str, prompt: str, temperature: float, base_url: str, logger: logging.Logger) -> Tuple[Optional[str], Optional[str]]:
+import aiohttp
+import asyncio # Added for timeout
+from cachetools import LFUCache
+
+# Simple in-memory cache for LLM responses
+# Cache up to 128 entries, with LFU replacement policy
+llm_cache = LFUCache(maxsize=128)
+# You might want to make cache configuration (size, TTL) part of hephaestus_config.json
+
+async def call_llm_api(
+    api_key: str,
+    model: str,
+    prompt: str,
+    temperature: float,
+    base_url: str,
+    logger: logging.Logger,
+    timeout_seconds: int = 60,  # Default timeout for the API call
+    use_cache: bool = True # Flag to control caching
+) -> Tuple[Optional[str], Optional[str]]:
     """
-    Helper function to make calls to the LLM API.
-
-    Args:
-        api_key: The API key for authentication.
-        model: The model to use for the completion.
-        prompt: The prompt to send to the model.
-        temperature: The temperature for sampling.
-        base_url: The base URL for the API.
-        logger: Logger instance for logging.
-
-    Returns:
-        A tuple containing the content of the response (or None if an error occurred)
-        and an error message (or None if successful).
+    Helper function to make calls to the LLM API asynchronously.
+    Includes caching and timeout.
     """
+    cache_key = None
+    if use_cache:
+        # Create a cache key based on relevant parameters
+        # Hashing the prompt can be good if it's very long
+        # For simplicity, using a tuple of model, prompt (or its hash), and temperature
+        try:
+            prompt_hash = str(hash(prompt)) # Simple hash
+        except Exception: # pragma: no cover
+            prompt_hash = prompt # Fallback if hashing fails for some reason
+        cache_key = (model, prompt_hash, temperature, base_url)
+        if cache_key in llm_cache:
+            if logger:
+                logger.info(f"Returning cached response for model {model}, prompt hash {prompt_hash}")
+            return llm_cache[cache_key]
+
     url = f"{base_url}/chat/completions"
     headers = {
         "Authorization": f"Bearer {api_key}",
@@ -33,54 +51,76 @@ def call_llm_api(api_key: str, model: str, prompt: str, temperature: float, base
         "messages": [{"role": "user", "content": prompt}],
         "temperature": temperature
     }
+
     try:
-        response = requests.post(url, json=payload, headers=headers)
-        response.raise_for_status()  # Raises an HTTPError for bad responses (4XX or 5XX)
-        response_json = response.json()
+        async with aiohttp.ClientSession() as session:
+            async with session.post(
+                url,
+                json=payload,
+                headers=headers,
+                timeout=aiohttp.ClientTimeout(total=timeout_seconds)
+            ) as response:
+                response_text = await response.text() # Read text first for better error reporting
+                response.raise_for_status()  # Raises an ClientResponseError for bad responses (4XX or 5XX)
 
-        if logger:
-            logger.debug(f"LLM API Response: {json.dumps(response_json, indent=2)}")
+                try:
+                    response_json = json.loads(response_text)
+                except json.JSONDecodeError as json_err:
+                    err_msg = f"JSON decode error: {json_err}. Response text: {response_text[:500]}"
+                    if logger: logger.error(err_msg)
+                    return None, err_msg
 
-        if "choices" not in response_json or not response_json["choices"]:
-            err_msg = "API response missing 'choices' key or 'choices' is empty."
-            if logger:
-                logger.error(f"{err_msg} Full response: {response_json}")
-            return None, f"{err_msg} Full response: {response_json}"
+                if logger:
+                    logger.debug(f"LLM API Response: {json.dumps(response_json, indent=2)}")
 
-        # Check if message and content are present
-        message = response_json["choices"][0].get("message")
-        if not message:
-            err_msg = "API response 'choices'[0] missing 'message' key."
-            if logger:
-                logger.error(f"{err_msg} Full response: {response_json}")
-            return None, f"{err_msg} Full response: {response_json}"
+                if "choices" not in response_json or not response_json["choices"]:
+                    err_msg = "API response missing 'choices' key or 'choices' is empty."
+                    # Avoid logging full response_json if it's huge or sensitive without redaction
+                    if logger: logger.error(f"{err_msg} Response keys: {list(response_json.keys())}")
+                    return None, err_msg
 
-        content = message.get("content")
-        if content is None: # content can be an empty string, which is valid
-            err_msg = "API response 'message' missing 'content' key."
-            if logger:
-                logger.error(f"{err_msg} Full response: {response_json}")
-            return None, f"{err_msg} Full response: {response_json}"
+                message = response_json["choices"][0].get("message")
+                if not message:
+                    err_msg = "API response 'choices'[0] missing 'message' key."
+                    if logger: logger.error(err_msg)
+                    return None, err_msg
 
-        return content, None
-    except requests.exceptions.HTTPError as http_err:
-        error_details = f"HTTP error occurred: {http_err} - Status: {http_err.response.status_code}, Response: {http_err.response.text}"
-        if logger:
-            logger.error(error_details)
+                content = message.get("content")
+                if content is None:
+                    err_msg = "API response 'message' missing 'content' key."
+                    if logger: logger.error(err_msg)
+                    return None, err_msg
+
+                if use_cache and cache_key:
+                    llm_cache[cache_key] = (content, None)
+
+                return content, None
+
+    except aiohttp.ClientResponseError as http_err:
+        # response_text might already be defined if status check passed initially but something else failed
+        # For raise_for_status, response_text is available via http_err.message if not read before
+        # However, reading it before raise_for_status is safer for detailed logging.
+        error_details = f"HTTP error occurred: {http_err.status} {http_err.message}. Response: {response_text[:500]}"
+        if logger: logger.error(error_details)
         return None, error_details
-    except requests.exceptions.RequestException as req_err:
-        error_details = f"Request failed: {req_err}"
-        if logger:
-            logger.error(error_details)
+    except asyncio.TimeoutError:
+        error_details = f"API call timed out after {timeout_seconds} seconds for model {model} at {url}"
+        if logger: logger.error(error_details)
         return None, error_details
-    except KeyError as key_err:
-        error_details = f"KeyError: {str(key_err)} in API response. This might indicate an unexpected response structure."
-        if logger:
-            logger.error(f"{error_details} Full response: {response_json}")
+    except aiohttp.ClientError as client_err: # Catches other aiohttp client errors (e.g., connection errors)
+        error_details = f"AIOHTTP client error: {client_err}"
+        if logger: logger.error(error_details)
         return None, error_details
-    except Exception as e:
-        # Using traceback here to get more details on unexpected errors
+    except KeyError as key_err: # Should be less likely with .get() usage but good as a safeguard
+        # response_json might not be defined if error is early
+        err_response_text = "response_json not available"
+        try:
+            err_response_text = json.dumps(response_json) if 'response_json' in locals() else response_text
+        except Exception: pass # pragma: no cover
+        error_details = f"KeyError: {str(key_err)} in API response. Response (partial): {err_response_text[:500]}"
+        if logger: logger.error(error_details)
+        return None, error_details
+    except Exception as e: # General catch-all
         error_details = f"Unexpected error during LLM API call: {str(e)}\n{traceback.format_exc()}"
-        if logger:
-            logger.error(error_details)
+        if logger: logger.error(error_details)
         return None, error_details


### PR DESCRIPTION
Introduces asynchronous LLM calls using aiohttp and cachetools in llm_client.py.

Key changes:
- `agent.utils.llm_client.call_llm_api` is now `async def` and uses `aiohttp`.
- Added LFU cache for LLM responses in `llm_client`.
- `ArchitectAgent.plan_action` and `MaestroAgent.choose_strategy` in `agent.agents.py` are now `async def` and await `call_llm_api`.
- Comments added to `agent.cycle_runner.py` to illustrate integration points for the async methods.

This PoC demonstrates the feasibility of the asynchronous approach for performance optimization.

Next Steps (outlined in the optimization plan):
- Fully integrate async/await throughout the `CycleRunner` and `HephaestusAgent`.
- Adapt `tool_executor.py` and validation steps for asynchronous operations.
- Update all relevant tests to use `pytest-asyncio`.
- Install new dependencies (`aiohttp`, `cachetools`).